### PR TITLE
Generic combinators

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,6 @@ import PackageDescription
 let package = Package(
   name: "SwiftParse",
   dependencies: [
-    .Package(url: "https://github.com/mgadda/swift-ext", majorVersion: 0)
+    .Package(url: "https://github.com/mgadda/swift-ext", majorVersion: 0, minor: 3)
   ]
 )

--- a/Sources/Combinators.swift
+++ b/Sources/Combinators.swift
@@ -13,7 +13,11 @@ public func head<Element>(_ source: [Element]) -> Element? {
 }
 
 public func tail<Element>(_ source: [Element]) -> [Element] {
-  return Array(source[1..<source.count])
+  if source.count <= 1 {
+    return []
+  } else {
+    return Array(source[1..<source.count])
+  }
 }
 
 public func acceptIf<T>(_ source: [T], fn: @escaping (T) -> Bool) -> (T, [T])? {

--- a/Sources/Combinators.swift
+++ b/Sources/Combinators.swift
@@ -35,10 +35,10 @@ public func accept<T: Equatable>(_ value: T) -> HomogeneousParser<T> {
 func accept<T: Equatable>(_ values: [T]) -> HeterogeneousParser<T, [T]> {
   let parsers = values.map { accept($0) }
   typealias Result = ([T], [T])
-  let initial: Result? = ([], values)
 
   return { (source: [T]) -> Result? in
-    parsers.reduce(initial, { (maybeResult, parser) in
+    let initial: Result? = ([], source)
+    return parsers.reduce(initial, { (maybeResult, parser) in
       maybeResult.flatMap { result in
         parser(result.1).map { (result.0 + [$0.0], $0.1) }
       }

--- a/Sources/Combinators.swift
+++ b/Sources/Combinators.swift
@@ -26,8 +26,24 @@ public func acceptIf<T>(_ source: [T], fn: @escaping (T) -> Bool) -> (T, [T])? {
   }
 }
 
+// Generates a parser which matches a single value of type T
 public func accept<T: Equatable>(_ value: T) -> HomogeneousParser<T> {
   return { source in acceptIf(source) { $0 == value } }
+}
+
+// Generates a parser which matches an array of values of type T
+func accept<T: Equatable>(_ ts: [T]) -> HeterogeneousParser<T, [T]> {
+  let parsers = ts.map { accept($0) }
+  typealias Result = ([T], [T])
+  let initial: Result? = ([], ts)
+
+  return { (source: [T]) -> Result? in
+    parsers.reduce(initial, { (maybeResult, parser) in
+      maybeResult.flatMap { result in
+        parser(result.1).map { (result.0 + [$0.0], $0.1) }
+      }
+    })
+  }
 }
 
 // Generate parser which attempts to match first `left`

--- a/Sources/Combinators.swift
+++ b/Sources/Combinators.swift
@@ -187,5 +187,15 @@ public postfix func *?<T, StreamToken>(_ parser: @autoclosure @escaping () -> He
   return opt(parser)
 }
 
+public func not<T: Equatable>(_ value: T) -> HomogeneousParser<T> {
+  return { source in
+    return acceptIf(source) { $0 != value }
+  }
+}
+
+public func until<T: Equatable>(_ value: T) -> HeterogeneousParser<T, [T]> {
+  return rep1(not(value))
+}
+
 
 public func placeholder<T, StreamToken>(_ source: [StreamToken]) -> (T, [StreamToken])? { return .none }

--- a/Sources/Lexical.swift
+++ b/Sources/Lexical.swift
@@ -1,7 +1,9 @@
 import SwiftExt
 
 // TODO: replace HeterogeneousParser references below with this typealias
-// once https://bugs.swift.org/browse/SR-3640 has been resolved.
+// once Xcode 8.2, which fixes  https://bugs.swift.org/browse/SR-3640 has 
+// been released.
+//
 // typealias LexicalParser = HeterogeneousParser<Character, String>
 
 public enum Token : Equatable {

--- a/Sources/Lexical.swift
+++ b/Sources/Lexical.swift
@@ -68,3 +68,14 @@ public func integerLiteral(_ source: [Character]) -> (Token, [Character])? {
   }
 }
 
+// TODO: support multi-character (String) stopChars 
+public func comment<T>(startingWith: String, until stopChar: Character = "\n", token: T) -> HeterogeneousParser<Character, T> {
+  let parser = accept(stringToArray(startingWith)) ~ until(stopChar) ^^ { _ in token }
+  return { source in parser(source) }
+}
+
+public func commentWithContent(startingWith: String, until stopChar: Character = "\n") -> HeterogeneousParser<Character, String> {
+  let parser = accept(stringToArray(startingWith)) ~ until(stopChar) ^^ { (_, comment) in String(comment) }
+  return { source in parser(source) }
+}
+

--- a/Sources/Lexical.swift
+++ b/Sources/Lexical.swift
@@ -1,5 +1,9 @@
 import SwiftExt
 
+// TODO: replace HeterogeneousParser references below with this typealias
+// once https://bugs.swift.org/browse/SR-3640 has been resolved.
+// typealias LexicalParser = HeterogeneousParser<Character, String>
+
 public enum Token : Equatable {
   case whitespace
   case integerLiteral(Int)
@@ -28,7 +32,7 @@ public func letter(_ source: [Character]) -> (Character, [Character])? {
   }
 }
 
-public func word(_ value: String) -> ([Character]) -> (String, [Character])? {
+public func word(_ value: String) -> HeterogeneousParser<Character, String> {
   let wordParser = letter+ ^^ { String($0) }
 
   return { source in
@@ -36,7 +40,7 @@ public func word(_ value: String) -> ([Character]) -> (String, [Character])? {
   }
 }
 
-public func char(_ value: Character) -> ([Character]) -> (String, [Character])? {
+public func char(_ value: Character) -> HeterogeneousParser<Character, String> {
   return accept(value) ^^ { String($0) }
 }
 

--- a/Sources/Lexical.swift
+++ b/Sources/Lexical.swift
@@ -22,7 +22,7 @@ public enum Token : Equatable {
 }
 
 public func whitespace(_ source: [Character]) -> (Token, [Character])? {
-  let parser = map(accept(Character(" "))) { _ in Token.whitespace }
+  let parser = map(char(" ")) { _ in Token.whitespace }
   return parser(source)
 }
 
@@ -52,7 +52,7 @@ public func digit(_ source: [Character]) -> (Character, [Character])? {
 
 
 public func integerLiteral(_ source: [Character]) -> (Token, [Character])? {
-  let intParser = (accept("+") | accept("-"))*? ~ rep1(digit)
+  let intParser = (char("+") | char("-"))*? ~ rep1(digit)
 
   return intParser(source).flatMap { result in
     var sign = 1

--- a/Sources/Lexical.swift
+++ b/Sources/Lexical.swift
@@ -16,7 +16,7 @@ public enum Token : Equatable {
 }
 
 public func whitespace(_ source: [Character]) -> (Token, [Character])? {
-  let parser = map(accept(" ")) { _ in Token.whitespace }
+  let parser = map(accept(Character(" "))) { _ in Token.whitespace }
   return parser(source)
 }
 
@@ -34,6 +34,10 @@ public func word(_ value: String) -> ([Character]) -> (String, [Character])? {
   return { source in
     wordParser(source).filter { $0.0 == value }
   }
+}
+
+public func char(_ value: Character) -> ([Character]) -> (String, [Character])? {
+  return accept(value) ^^ { String($0) }
 }
 
 public func digit(_ source: [Character]) -> (Character, [Character])? {

--- a/Sources/Lexical.swift
+++ b/Sources/Lexical.swift
@@ -62,12 +62,25 @@ public func integerLiteral(_ source: [Character]) -> (Int, [Character])? {
 
 // TODO: support multi-character (String) stopChars 
 public func comment<T>(startingWith: String, until stopChar: Character = "\n", token: T) -> HeterogeneousParser<Character, T> {
-  let parser = accept(stringToArray(startingWith)) ~ until(stopChar) ^^ { _ in token }
+  let parser = commentWithContent(startingWith: startingWith, until: stopChar) ^^ { _ in token }
   return { source in parser(source) }
 }
 
 public func commentWithContent(startingWith: String, until stopChar: Character = "\n") -> HeterogeneousParser<Character, String> {
   let parser = accept(stringToArray(startingWith)) ~ until(stopChar) ^^ { (_, comment) in String(comment) }
+  return { source in parser(source) }
+}
+
+public func comment<T>(startingWith: String, until endingWith: String, token: T) -> HeterogeneousParser<Character, T> {
+  let parser = commentWithContent(startingWith: startingWith, until: endingWith) ^^ { _ in token }
+  return { source in parser(source) }
+}
+
+public func commentWithContent(startingWith: String, until endingWith: String) -> HeterogeneousParser<Character, String> {
+  let startWithParser = accept(stringToArray(startingWith))
+  let endingWithParser = accept(stringToArray(endingWith))
+
+  let parser = startWithParser ~ until(endingWithParser) ^^ { (_, comment) in String(comment) }
   return { source in parser(source) }
 }
 

--- a/Sources/Lexical.swift
+++ b/Sources/Lexical.swift
@@ -6,23 +6,15 @@ import SwiftExt
 //
 // typealias LexicalParser = HeterogeneousParser<Character, String>
 
-public enum Token : Equatable {
-  case whitespace
-  case integerLiteral(Int)
-
-  public static func ==(lhs: Token, rhs: Token) -> Bool {
-    switch (lhs, rhs) {
-      case (.whitespace, .whitespace): return true
-      case let (.integerLiteral(leftVal), .integerLiteral(rightVal)):
-        return leftVal == rightVal
-      default:
-        return false
-    }
+public func whitespace<T>(token: T) -> HeterogeneousParser<Character, T> {
+  let parser = whitespaceWithContent ^^ { _ in token }
+  return { source in
+    parser(source)
   }
 }
 
-public func whitespace(_ source: [Character]) -> (Token, [Character])? {
-  let parser = map(char(" ")) { _ in Token.whitespace }
+public func whitespaceWithContent(_ source: [Character]) -> (String, [Character])? {
+  let parser = char(" ") | char("\n") | char("\t")
   return parser(source)
 }
 
@@ -51,7 +43,7 @@ public func digit(_ source: [Character]) -> (Character, [Character])? {
 }
 
 
-public func integerLiteral(_ source: [Character]) -> (Token, [Character])? {
+public func integerLiteral(_ source: [Character]) -> (Int, [Character])? {
   let intParser = (char("+") | char("-"))*? ~ rep1(digit)
 
   return intParser(source).flatMap { result in
@@ -63,7 +55,7 @@ public func integerLiteral(_ source: [Character]) -> (Token, [Character])? {
     default: break
     }
     return Int(String(result.0.1)).map { intVal in
-      (.integerLiteral(intVal * sign), result.1)
+      (intVal * sign, result.1)
     }
   }
 }

--- a/Sources/Map.swift
+++ b/Sources/Map.swift
@@ -1,0 +1,213 @@
+//
+//  Map.swift
+//  llama
+//
+//  Created by Matthew Gadda on 1/13/17.
+//
+//
+import SwiftExt
+
+// Generate parser which converts the parsed result into type U
+public func map<T, U, StreamToken>(
+  _ parser: @autoclosure @escaping () -> HeterogeneousParser<StreamToken, T>,
+  fn: @escaping (T) -> U
+  ) -> HeterogeneousParser<StreamToken, U> {
+  return { source in
+    parser()(source).map { mapResult($0, fn) }
+  }
+}
+
+public func map<T1, T2, U, StreamToken>(
+  _ parser: @autoclosure @escaping () -> HeterogeneousParser<StreamToken, (T1, T2)>,
+  fn: @escaping (T1, T2) -> U
+  ) -> HeterogeneousParser<StreamToken, U> {
+  return { source in
+    parser()(source).map { mapResult($0, fn) }
+  }
+}
+
+public func map<T1, T2, T3, U, StreamToken>(
+  _ parser: @autoclosure @escaping () -> HeterogeneousParser<StreamToken, ((T1, T2), T3)>,
+  fn: @escaping (T1, T2, T3) -> U
+  ) -> HeterogeneousParser<StreamToken, U> {
+  return { source in
+    parser()(source).map { mapResult($0, fn) }
+  }
+}
+
+public func map<T1, T2, T3, T4, U, StreamToken>(
+  _ parser: @autoclosure @escaping () -> HeterogeneousParser<StreamToken, (((T1, T2), T3), T4)>,
+  fn: @escaping (T1, T2, T3, T4) -> U
+  ) -> HeterogeneousParser<StreamToken, U> {
+  return { source in
+    parser()(source).map { mapResult($0, fn) }
+  }
+}
+
+public func map<T1, T2, T3, T4, T5, U, StreamToken>(
+  _ parser: @autoclosure @escaping () -> HeterogeneousParser<StreamToken, ((((T1, T2), T3), T4), T5)>,
+  fn: @escaping (T1, T2, T3, T4, T5) -> U
+  ) -> HeterogeneousParser<StreamToken, U> {
+  return { source in
+    parser()(source).map { mapResult($0, fn) }
+  }
+}
+
+public func map<T1, T2, T3, T4, T5, T6, U, StreamToken>(
+  _ parser: @autoclosure @escaping () -> HeterogeneousParser<StreamToken, (((((T1, T2), T3), T4), T5), T6)>,
+  fn: @escaping (T1, T2, T3, T4, T5, T6) -> U
+  ) -> HeterogeneousParser<StreamToken, U> {
+  return { source in
+    parser()(source).map { mapResult($0, fn) }
+  }
+}
+
+public func map<T1, T2, T3, T4, T5, T6, T7, U, StreamToken>(
+  _ parser: @autoclosure @escaping () -> HeterogeneousParser<StreamToken, ((((((T1, T2), T3), T4), T5), T6), T7)>,
+  fn: @escaping (T1, T2, T3, T4, T5, T6, T7) -> U
+  ) -> HeterogeneousParser<StreamToken, U> {
+  return { source in
+    parser()(source).map { mapResult($0, fn) }
+  }
+}
+
+public func map<T1, T2, T3, T4, T5, T6, T7, T8, U, StreamToken>(
+  _ parser: @autoclosure @escaping () -> HeterogeneousParser<StreamToken, (((((((T1, T2), T3), T4), T5), T6), T7), T8)>,
+  fn: @escaping (T1, T2, T3, T4, T5, T6, T7, T8) -> U
+  ) -> HeterogeneousParser<StreamToken, U> {
+  return { source in
+    parser()(source).map { mapResult($0, fn) }
+  }
+}
+
+
+public func flatMap<T, U, StreamToken>(
+  _ parser: @autoclosure @escaping () -> ([StreamToken]) -> (T, [StreamToken])?,
+  fn: @escaping (T) -> U?
+  ) -> HeterogeneousParser<StreamToken, U> {
+  return { source in
+    parser()(source).flatMap { flatMapResult($0, fn) }
+  }
+}
+
+precedencegroup MapGroup {
+  higherThan: AssignmentPrecedence
+  lowerThan: AdditionPrecedence
+}
+infix operator ^^: MapGroup
+public func ^^<T, U, StreamToken>(
+  _ parser: @autoclosure @escaping () -> ([StreamToken]) -> (T, [StreamToken])?,
+  fn: @escaping (T) -> U
+  ) -> HeterogeneousParser<StreamToken, U> {
+  return map(parser, fn: fn)
+}
+
+public func ^^<T1, T2, U, StreamToken>(
+  _ parser: @autoclosure @escaping () -> ([StreamToken]) -> ((T1, T2), [StreamToken])?,
+  fn: @escaping (T1, T2) -> U
+  ) -> HeterogeneousParser<StreamToken, U> {
+  return map(parser, fn: fn)
+}
+
+public func ^^<T1, T2, T3, U, StreamToken>(
+  _ parser: @autoclosure @escaping () -> ([StreamToken]) -> (((T1, T2), T3), [StreamToken])?,
+  fn: @escaping (T1, T2, T3) -> U
+  ) -> HeterogeneousParser<StreamToken, U> {
+  return map(parser, fn: fn)
+}
+
+public func ^^<T1, T2, T3, T4, U, StreamToken>(
+  _ parser: @autoclosure @escaping () -> ([StreamToken]) -> ((((T1, T2), T3), T4), [StreamToken])?,
+  fn: @escaping (T1, T2, T3, T4) -> U
+  ) -> HeterogeneousParser<StreamToken, U> {
+  return map(parser, fn: fn)
+}
+
+public func ^^<T1, T2, T3, T4, T5, U, StreamToken>(
+  _ parser: @autoclosure @escaping () -> ([StreamToken]) -> (((((T1, T2), T3), T4), T5), [StreamToken])?,
+  fn: @escaping (T1, T2, T3, T4, T5) -> U
+  ) -> HeterogeneousParser<StreamToken, U> {
+  return map(parser, fn: fn)
+}
+
+public func ^^<T1, T2, T3, T4, T5, T6, U, StreamToken>(
+  _ parser: @autoclosure @escaping () -> ([StreamToken]) -> ((((((T1, T2), T3), T4), T5), T6), [StreamToken])?,
+  fn: @escaping (T1, T2, T3, T4, T5, T6) -> U
+  ) -> HeterogeneousParser<StreamToken, U> {
+  return map(parser, fn: fn)
+}
+
+public func ^^<T1, T2, T3, T4, T5, T6, T7, U, StreamToken>(
+  _ parser: @autoclosure @escaping () -> ([StreamToken]) -> (((((((T1, T2), T3), T4), T5), T6), T7), [StreamToken])?,
+  fn: @escaping (T1, T2, T3, T4, T5, T6, T7) -> U
+  ) -> HeterogeneousParser<StreamToken, U> {
+  return map(parser, fn: fn)
+}
+
+public func ^^<T1, T2, T3, T4, T5, T6, T7, T8, U, StreamToken>(
+  _ parser: @autoclosure @escaping () -> ([StreamToken]) -> ((((((((T1, T2), T3), T4), T5), T6), T7), T8), [StreamToken])?,
+  fn: @escaping (T1, T2, T3, T4, T5, T6, T7, T8) -> U
+  ) -> HeterogeneousParser<StreamToken, U> {
+  return map(parser, fn: fn)
+}
+
+infix operator ^^-: MapGroup
+public func ^^-<T, U>(
+  _ parser: @autoclosure @escaping () -> ([Character]) -> (T, [Character])?,
+  fn: @escaping (T) -> U?
+  ) -> ([Character]) -> (U, [Character])? {
+  return flatMap(parser, fn: fn)
+}
+
+public func mapResult<T, U, StreamToken>(_ result: (T, [StreamToken]), _ fn: (T) -> U) -> (U, [StreamToken]) {
+  return (fn(result.0), result.1)
+}
+
+public func mapResult<T1, T2, U, StreamToken>(
+  _ result: ((T1, T2), [StreamToken]),
+  _ fn: @escaping (T1, T2) -> U) -> (U, [StreamToken]
+) {
+  return (tupled(fn)(result.0), result.1)
+}
+
+public func mapResult<T1, T2, T3, U, StreamToken>(
+  _ result: (((T1, T2), T3), [StreamToken]),
+  _ fn: @escaping (T1, T2, T3) -> U) -> (U, [StreamToken]
+) {
+  return (nested(fn)(result.0), result.1)
+}
+
+public func mapResult<T1, T2, T3, T4, U, StreamToken>(
+  _ result: ((((T1, T2), T3), T4), [StreamToken]),
+  _ fn: @escaping (T1, T2, T3, T4) -> U) -> (U, [StreamToken]
+) {
+  return (nested(fn)(result.0), result.1)
+}
+
+public func mapResult<T1, T2, T3, T4, T5, U, StreamToken>(
+  _ result: (((((T1, T2), T3), T4), T5), [StreamToken]),
+  _ fn: @escaping (T1, T2, T3, T4, T5) -> U) -> (U, [StreamToken]) {
+  return (nested(fn)(result.0), result.1)
+}
+
+public func mapResult<T1, T2, T3, T4, T5, T6, U, StreamToken>(
+  _ result: ((((((T1, T2), T3), T4), T5), T6), [StreamToken]),
+  _ fn: @escaping (T1, T2, T3, T4, T5, T6) -> U) -> (U, [StreamToken]) {
+  return (nested(fn)(result.0), result.1)
+}
+
+public func mapResult<T1, T2, T3, T4, T5, T6, T7, U, StreamToken>(
+  _ result: (((((((T1, T2), T3), T4), T5), T6), T7), [StreamToken]),
+  _ fn: @escaping (T1, T2, T3, T4, T5, T6, T7) -> U) -> (U, [StreamToken]) {
+  return (nested(fn)(result.0), result.1)
+}
+
+public func mapResult<T1, T2, T3, T4, T5, T6, T7, T8, U, StreamToken>(
+  _ result: ((((((((T1, T2), T3), T4), T5), T6), T7), T8), [StreamToken]),
+  _ fn: @escaping (T1, T2, T3, T4, T5, T6, T7, T8) -> U) -> (U, [StreamToken]) {
+  return (nested(fn)(result.0), result.1)
+}
+
+public func flatMapResult<T, U, StreamToken>(_ result: (T, [StreamToken]), _ fn: (T) -> U?) -> (U, [StreamToken])? {
+  return fn(result.0).map { ($0, result.1) }
+}

--- a/Sources/Map.swift
+++ b/Sources/Map.swift
@@ -82,7 +82,7 @@ public func map<T1, T2, T3, T4, T5, T6, T7, T8, U, StreamToken>(
 
 
 public func flatMap<T, U, StreamToken>(
-  _ parser: @autoclosure @escaping () -> ([StreamToken]) -> (T, [StreamToken])?,
+  _ parser: @autoclosure @escaping () -> HeterogeneousParser<StreamToken, T>,
   fn: @escaping (T) -> U?
   ) -> HeterogeneousParser<StreamToken, U> {
   return { source in
@@ -96,66 +96,66 @@ precedencegroup MapGroup {
 }
 infix operator ^^: MapGroup
 public func ^^<T, U, StreamToken>(
-  _ parser: @autoclosure @escaping () -> ([StreamToken]) -> (T, [StreamToken])?,
+  _ parser: @autoclosure @escaping () -> HeterogeneousParser<StreamToken, T>,
   fn: @escaping (T) -> U
   ) -> HeterogeneousParser<StreamToken, U> {
   return map(parser, fn: fn)
 }
 
 public func ^^<T1, T2, U, StreamToken>(
-  _ parser: @autoclosure @escaping () -> ([StreamToken]) -> ((T1, T2), [StreamToken])?,
+  _ parser: @autoclosure @escaping () -> HeterogeneousParser<StreamToken, (T1, T2)>,
   fn: @escaping (T1, T2) -> U
   ) -> HeterogeneousParser<StreamToken, U> {
   return map(parser, fn: fn)
 }
 
 public func ^^<T1, T2, T3, U, StreamToken>(
-  _ parser: @autoclosure @escaping () -> ([StreamToken]) -> (((T1, T2), T3), [StreamToken])?,
+  _ parser: @autoclosure @escaping () -> HeterogeneousParser<StreamToken, ((T1, T2), T3)>,
   fn: @escaping (T1, T2, T3) -> U
   ) -> HeterogeneousParser<StreamToken, U> {
   return map(parser, fn: fn)
 }
 
 public func ^^<T1, T2, T3, T4, U, StreamToken>(
-  _ parser: @autoclosure @escaping () -> ([StreamToken]) -> ((((T1, T2), T3), T4), [StreamToken])?,
+  _ parser: @autoclosure @escaping () -> HeterogeneousParser<StreamToken, (((T1, T2), T3), T4)>,
   fn: @escaping (T1, T2, T3, T4) -> U
   ) -> HeterogeneousParser<StreamToken, U> {
   return map(parser, fn: fn)
 }
 
 public func ^^<T1, T2, T3, T4, T5, U, StreamToken>(
-  _ parser: @autoclosure @escaping () -> ([StreamToken]) -> (((((T1, T2), T3), T4), T5), [StreamToken])?,
+  _ parser: @autoclosure @escaping () -> HeterogeneousParser<StreamToken, ((((T1, T2), T3), T4), T5)>,
   fn: @escaping (T1, T2, T3, T4, T5) -> U
   ) -> HeterogeneousParser<StreamToken, U> {
   return map(parser, fn: fn)
 }
 
 public func ^^<T1, T2, T3, T4, T5, T6, U, StreamToken>(
-  _ parser: @autoclosure @escaping () -> ([StreamToken]) -> ((((((T1, T2), T3), T4), T5), T6), [StreamToken])?,
+  _ parser: @autoclosure @escaping () -> HeterogeneousParser<StreamToken, (((((T1, T2), T3), T4), T5), T6)>,
   fn: @escaping (T1, T2, T3, T4, T5, T6) -> U
   ) -> HeterogeneousParser<StreamToken, U> {
   return map(parser, fn: fn)
 }
 
 public func ^^<T1, T2, T3, T4, T5, T6, T7, U, StreamToken>(
-  _ parser: @autoclosure @escaping () -> ([StreamToken]) -> (((((((T1, T2), T3), T4), T5), T6), T7), [StreamToken])?,
+  _ parser: @autoclosure @escaping () -> HeterogeneousParser<StreamToken, ((((((T1, T2), T3), T4), T5), T6), T7)>,
   fn: @escaping (T1, T2, T3, T4, T5, T6, T7) -> U
   ) -> HeterogeneousParser<StreamToken, U> {
   return map(parser, fn: fn)
 }
 
 public func ^^<T1, T2, T3, T4, T5, T6, T7, T8, U, StreamToken>(
-  _ parser: @autoclosure @escaping () -> ([StreamToken]) -> ((((((((T1, T2), T3), T4), T5), T6), T7), T8), [StreamToken])?,
+  _ parser: @autoclosure @escaping () -> HeterogeneousParser<StreamToken, (((((((T1, T2), T3), T4), T5), T6), T7), T8)>,
   fn: @escaping (T1, T2, T3, T4, T5, T6, T7, T8) -> U
   ) -> HeterogeneousParser<StreamToken, U> {
   return map(parser, fn: fn)
 }
 
 infix operator ^^-: MapGroup
-public func ^^-<T, U>(
-  _ parser: @autoclosure @escaping () -> ([Character]) -> (T, [Character])?,
+public func ^^-<T, U, StreamToken>(
+  _ parser: @autoclosure @escaping () -> HeterogeneousParser<StreamToken, T>,
   fn: @escaping (T) -> U?
-  ) -> ([Character]) -> (U, [Character])? {
+  ) -> HeterogeneousParser<StreamToken, U> {
   return flatMap(parser, fn: fn)
 }
 

--- a/Sources/Util.swift
+++ b/Sources/Util.swift
@@ -1,3 +1,3 @@
 public func stringToArray(_ string: String) -> [Character] {
-  return string.characters.map { $0 }
+  return Array(string.characters)
 }

--- a/Tests/SwiftParseTests/CombinatorsTests.swift
+++ b/Tests/SwiftParseTests/CombinatorsTests.swift
@@ -6,4 +6,16 @@ class CombinatorsTests : XCTestCase {
     let result = head(["0", "1", "2"])
     XCTAssertEqual(result!, .some("0"))
   }
+  func testTail() {
+    var result = tail(["1", "2"])
+    XCTAssertEqual(result, ["2"])
+
+    result = tail(["2"])
+    XCTAssertEqual(result, [])
+  }
+
+  func testEmptyTail() {
+    let result: [Character] = tail([])
+    XCTAssertEqual(result, [Character]())
+  }
 }

--- a/Tests/SwiftParseTests/CombinatorsTests.swift
+++ b/Tests/SwiftParseTests/CombinatorsTests.swift
@@ -1,11 +1,16 @@
 import XCTest
 @testable import SwiftParse
 
-class CombinatorsTests : XCTestCase {
+class CombinatorsTests : XCTestCase, ParserHelpers {
   func testHead() {
     let result = head(["0", "1", "2"])
     XCTAssertEqual(result!, .some("0"))
   }
+  func testEmptyHead() {
+    let result = head([])
+    XCTAssertNil(result)
+  }
+
   func testTail() {
     var result = tail(["1", "2"])
     XCTAssertEqual(result, ["2"])
@@ -17,5 +22,45 @@ class CombinatorsTests : XCTestCase {
   func testEmptyTail() {
     let result: [Character] = tail([])
     XCTAssertEqual(result, [Character]())
+  }
+
+  func testNot() {
+    assertParsed(not("a"), input: ["b", "c"], "b", ["c"])
+    assertNotParsed(not("a"), input: ["a", "b"])
+  }
+
+  func testNotParser() {
+    let notSpace = not(char(" "))
+    assertParsed(notSpace, input: ["a", "b"], "a", ["b"])
+    assertNotParsed(notSpace, input: [" ", "b"])
+  }
+
+  func testUntil() {
+    let parser = until(Character("\n"))
+    let result = parser(["a", "b" ,"\n"])
+    XCTAssertNotNil(result)
+    XCTAssertEqual(result!.0, ["a", "b"])
+    XCTAssertEqual(result!.1, ["\n"])
+  }
+
+  func testUntilParser() {
+    let parser = until(char("\n"))
+    let result = parser(["a", "b" ,"\n"])
+    XCTAssertNotNil(result)
+    XCTAssertEqual(result!.0, ["a", "b"])
+    XCTAssertEqual(result!.1, ["\n"])
+  }
+
+  func testAcceptValue() {
+    assertParsed(accept("a"), input: ["a", "b"], "a", ["b"])
+    assertNotParsed(accept("a"), input: ["b"])
+  }
+
+  func testAcceptValues() {
+    let parser = accept(["a", "b"])
+    let result = parser(["a", "b", "c", "d"])
+    XCTAssertNotNil(result)
+    XCTAssertEqual(result!.0, ["a", "b"])
+    XCTAssertEqual(result!.1, ["c", "d"])
   }
 }

--- a/Tests/SwiftParseTests/ParserHelpers.swift
+++ b/Tests/SwiftParseTests/ParserHelpers.swift
@@ -14,16 +14,27 @@ protocol ParserHelpers {
 
 extension ParserHelpers {
   func assertParsed<T: Equatable, U: Equatable>(
-    _ parser: ([U]) -> (T, [U])?,
-    input: [U],
-    _ val: T,
-    _ next: [U],
+    _ parser: ([T]) -> (U, [T])?,
+    input: [T],
+    _ val: U,
+    _ remaining: [T],
     _ message: @autoclosure () -> String = "",
     file: StaticString = #file,
     line: UInt = #line
   ) {
-    let result: (T, [U])? = parser(input)
+    let result: (U, [T])? = parser(input)
+    XCTAssertNotNil(result)
     XCTAssertEqual(result!.0, val, message, file: file, line: line)
-    XCTAssertEqual(result!.1, next, message, file: file, line: line)
+    XCTAssertEqual(result!.1, remaining, message, file: file, line: line)
+  }
+
+  func assertNotParsed<T: Equatable, U: Equatable>(
+    _ parser: ([T]) -> (U, [T])?,
+    input: [T],
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    XCTAssertNil(parser(input))
   }
 }


### PR DESCRIPTION
This PR contains a large number of improvements many of which non-backwards incompatible API changes. 

Here are some of the highlights:

* Combinators are now fully generic. 
* New higher-order combinators operating on parsers rather than individual tokens such as `not` and `until`
* `map`'s callback function now splats the tupled value into individual arguments
* `HeterogenousParser` and `HomogeneousParser` have replaced most of the adhoc parser types
* More tests have been added
