### PR TITLE
Improve error reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,3 @@ env:
 script:
   - swift package fetch
   - swift test
-#xcode_project: TypedOperation.xcodeproj
-# xcode_scheme: "SwiftParse"
-# xcode_sdk: iphonesimulator10.0
-# script: xcodebuild test -scheme "SwiftParse" -sdk iphonesimulator -destination "name=iPhone SE"

--- a/Sources/SwiftParse/Either.swift
+++ b/Sources/SwiftParse/Either.swift
@@ -1,4 +1,4 @@
-/// SwiftParse specific implementation of the algebraic Sum type representing
+/// SwiftParse specific implementation of the algebraic sum type representing
 /// values that are _either_ one type or another.
 public enum Either<T: Equatable, U: Equatable> : Equatable {
   case left(T)

--- a/Sources/SwiftParse/Map.swift
+++ b/Sources/SwiftParse/Map.swift
@@ -11,10 +11,10 @@
 public func map<T, U, StreamToken>(_ parser: @escaping Parser<StreamToken, T>, fn: @escaping (T) -> U) -> Parser<StreamToken, U> {
   return { source in
     switch parser(source) {
-    case let .some((t, remainder)):
-      return (fn(t), remainder)
+    case let .success((t, remainder)):
+      return .success((fn(t), remainder))
     default:
-      return nil
+      return .failure(ParseError(at: source))
     }
   }
 }

--- a/Sources/SwiftParse/Map.swift
+++ b/Sources/SwiftParse/Map.swift
@@ -10,11 +10,8 @@
 /// This parser fails if `parser` fails.
 public func map<T, U, StreamToken>(_ parser: @escaping Parser<StreamToken, T>, fn: @escaping (T) -> U) -> Parser<StreamToken, U> {
   return { source in
-    switch parser(source) {
-    case let .success((t, remainder)):
-      return .success((fn(t), remainder))
-    default:
-      return .failure(ParseError(at: source))
+    parser(source).map { (t, remainder) in
+      (fn(t), remainder)
     }
   }
 }

--- a/Sources/SwiftParse/Map.swift
+++ b/Sources/SwiftParse/Map.swift
@@ -8,20 +8,20 @@
 
 /// Generates a parser that invokes `fn` to convert the result value parsed by `parser` from type `T` to type `U`.
 /// This parser fails if `parser` fails.
-public func map<T, U, StreamToken>(_ parser: @escaping Parser<StreamToken, T>, fn: @escaping (T) -> U) -> Parser<StreamToken, U> {
+public func map<T, U, StreamToken>(_ parser: @autoclosure @escaping () -> Parser<StreamToken, T>, fn: @escaping (T) -> U) -> Parser<StreamToken, U> {
   return { source in
-    parser(source).map { (t, remainder) in
+    parser()(source).map { (t, remainder) in
       (fn(t), remainder)
     }
   }
 }
 
 public func map<T1, T2, T3, U, StreamToken>(
-  _ parser: @escaping Parser<StreamToken, ((T1, T2), T3)>,
+  _ parser: @autoclosure @escaping () -> Parser<StreamToken, ((T1, T2), T3)>,
   fn: @escaping (T1, T2, T3) -> U
   ) -> Parser<StreamToken, U> {
   return { source in
-    parser(source).map { (value, remainder) in
+    parser()(source).map { (value, remainder) in
       let ((t1, t2), t3) = value
       return (fn(t1, t2, t3), remainder)
     }
@@ -29,11 +29,11 @@ public func map<T1, T2, T3, U, StreamToken>(
 }
 
 public func map<T1, T2, T3, T4, U, StreamToken>(
-  _ parser: @escaping Parser<StreamToken, (((T1, T2), T3), T4)>,
+  _ parser: @autoclosure @escaping () -> Parser<StreamToken, (((T1, T2), T3), T4)>,
   fn: @escaping (T1, T2, T3, T4) -> U
   ) -> Parser<StreamToken, U> {
   return { source in
-    parser(source).map { (value, remainder) in
+    parser()(source).map { (value, remainder) in
       let (((t1, t2), t3), t4) = value
       return (fn(t1, t2, t3, t4), remainder)
     }
@@ -41,11 +41,11 @@ public func map<T1, T2, T3, T4, U, StreamToken>(
 }
 
 public func map<T1, T2, T3, T4, T5, U, StreamToken>(
-  _ parser: @escaping Parser<StreamToken, ((((T1, T2), T3), T4), T5)>,
+  _ parser: @autoclosure @escaping () -> Parser<StreamToken, ((((T1, T2), T3), T4), T5)>,
   fn: @escaping (T1, T2, T3, T4, T5) -> U
   ) -> Parser<StreamToken, U> {
   return { source in
-    parser(source).map { (value, remainder) in
+    parser()(source).map { (value, remainder) in
       let ((((t1, t2), t3), t4), t5) = value
       return (fn(t1, t2, t3, t4, t5), remainder)
     }
@@ -53,11 +53,11 @@ public func map<T1, T2, T3, T4, T5, U, StreamToken>(
 }
 
 public func map<T1, T2, T3, T4, T5, T6, U, StreamToken>(
-  _ parser: @escaping Parser<StreamToken, (((((T1, T2), T3), T4), T5), T6)>,
+  _ parser: @autoclosure @escaping () -> Parser<StreamToken, (((((T1, T2), T3), T4), T5), T6)>,
   fn: @escaping (T1, T2, T3, T4, T5, T6) -> U
   ) -> Parser<StreamToken, U> {
   return { source in
-    parser(source).map { (value, remainder) in
+    parser()(source).map { (value, remainder) in
       let (((((t1, t2), t3), t4), t5), t6) = value
       return (fn(t1, t2, t3, t4, t5, t6), remainder)
     }
@@ -65,11 +65,11 @@ public func map<T1, T2, T3, T4, T5, T6, U, StreamToken>(
 }
 
 public func map<T1, T2, T3, T4, T5, T6, T7, U, StreamToken>(
-  _ parser: @escaping Parser<StreamToken, ((((((T1, T2), T3), T4), T5), T6), T7)>,
+  _ parser: @autoclosure @escaping () -> Parser<StreamToken, ((((((T1, T2), T3), T4), T5), T6), T7)>,
   fn: @escaping (T1, T2, T3, T4, T5, T6, T7) -> U
   ) -> Parser<StreamToken, U> {
   return { source in
-    parser(source).map { (value, remainder) in
+    parser()(source).map { (value, remainder) in
       let ((((((t1, t2), t3), t4), t5), t6), t7) = value
       return (fn(t1, t2, t3, t4, t5, t6, t7), remainder)
     }
@@ -77,11 +77,11 @@ public func map<T1, T2, T3, T4, T5, T6, T7, U, StreamToken>(
 }
 
 public func map<T1, T2, T3, T4, T5, T6, T7, T8, U, StreamToken>(
-  _ parser: @escaping Parser<StreamToken, (((((((T1, T2), T3), T4), T5), T6), T7), T8)>,
+  _ parser: @autoclosure @escaping () -> Parser<StreamToken, (((((((T1, T2), T3), T4), T5), T6), T7), T8)>,
   fn: @escaping (T1, T2, T3, T4, T5, T6, T7, T8) -> U
   ) -> Parser<StreamToken, U> {
   return { source in
-    parser(source).map { (value, remainder) in
+    parser()(source).map { (value, remainder) in
       let (((((((t1, t2), t3), t4), t5), t6), t7), t8) = value
       return (fn(t1, t2, t3, t4, t5, t6, t7, t8), remainder)
     }

--- a/Sources/SwiftParse/Operators.swift
+++ b/Sources/SwiftParse/Operators.swift
@@ -7,35 +7,35 @@
 
 infix operator ~: MultiplicationPrecedence
 public func ~<T, U, StreamToken>(
-  _ left: @escaping Parser<StreamToken, T>,
-  _ right: @escaping Parser<StreamToken, U>
+  _ left: @autoclosure @escaping () -> Parser<StreamToken, T>,
+  _ right: @autoclosure @escaping () -> Parser<StreamToken, U>
   ) -> Parser<StreamToken, (T, U)> {
-  return seq(left, right)
+  return seq(left(), right())
 }
 
 infix operator ~>: MultiplicationPrecedence
 public func ~><T, U, StreamToken>(
-  _ left: @escaping Parser<StreamToken, T>,
-  _ right: @escaping Parser<StreamToken, U>
+  _ left: @autoclosure @escaping () -> Parser<StreamToken, T>,
+  _ right: @autoclosure @escaping () -> Parser<StreamToken, U>
   ) -> Parser<StreamToken, T> {
 
-  return map(seq(left, right)) { (left, _) in left }
+  return map(seq(left(), right())) { (left, _) in left }
 }
 
 infix operator <~: MultiplicationPrecedence
 public func <~<T, U, StreamToken>(
-  _ left: @escaping Parser<StreamToken, T>,
-  _ right: @escaping Parser<StreamToken, U>
+  _ left: @autoclosure @escaping () -> Parser<StreamToken, T>,
+  _ right: @autoclosure @escaping () -> Parser<StreamToken, U>
   ) -> Parser<StreamToken, U> {
 
-  return map(seq(left, right)) { (_, right) in right }
+  return map(seq(left(), right())) { (_, right) in right }
 }
 
 public func |<T, StreamToken>(
-  _ left: @escaping Parser<StreamToken, T>,
-  _ right: @escaping Parser<StreamToken, T>
+  _ left: @autoclosure @escaping () -> Parser<StreamToken, T>,
+  _ right: @autoclosure @escaping () -> Parser<StreamToken, T>
   ) -> Parser<StreamToken, T> {
-  return or(left, right)
+  return or(left(), right())
 }
 
 precedencegroup MapGroup {
@@ -45,66 +45,66 @@ precedencegroup MapGroup {
 
 infix operator ^^: MapGroup
 public func ^^<T, U, StreamToken>(
-  _ parser: @escaping Parser<StreamToken, T>,
+  _ parser: @autoclosure @escaping () -> Parser<StreamToken, T>,
   fn: @escaping (T) -> U
   ) -> Parser<StreamToken, U> {
-  return map(parser, fn: fn)
+  return map(parser(), fn: fn)
 }
 
 public func ^^<T1, T2, T3, U, StreamToken>(
-  _ parser: @escaping Parser<StreamToken, ((T1, T2), T3)>,
+  _ parser: @autoclosure @escaping () -> Parser<StreamToken, ((T1, T2), T3)>,
   fn: @escaping (T1, T2, T3) -> U
   ) -> Parser<StreamToken, U> {
-  return map(parser, fn: fn)
+  return map(parser(), fn: fn)
 }
 
 public func ^^<T1, T2, T3, T4, U, StreamToken>(
-  _ parser: @escaping Parser<StreamToken, (((T1, T2), T3), T4)>,
+  _ parser: @autoclosure @escaping () -> Parser<StreamToken, (((T1, T2), T3), T4)>,
   fn: @escaping (T1, T2, T3, T4) -> U
   ) -> Parser<StreamToken, U> {
-  return map(parser, fn: fn)
+  return map(parser(), fn: fn)
 }
 
 public func ^^<T1, T2, T3, T4, T5, U, StreamToken>(
-  _ parser: @escaping Parser<StreamToken, ((((T1, T2), T3), T4), T5)>,
+  _ parser: @autoclosure @escaping () -> Parser<StreamToken, ((((T1, T2), T3), T4), T5)>,
   fn: @escaping (T1, T2, T3, T4, T5) -> U
   ) -> Parser<StreamToken, U> {
-  return map(parser, fn: fn)
+  return map(parser(), fn: fn)
 }
 
 public func ^^<T1, T2, T3, T4, T5, T6, U, StreamToken>(
-  _ parser: @escaping Parser<StreamToken, (((((T1, T2), T3), T4), T5), T6)>,
+  _ parser: @autoclosure @escaping () -> Parser<StreamToken, (((((T1, T2), T3), T4), T5), T6)>,
   fn: @escaping (T1, T2, T3, T4, T5, T6) -> U
   ) -> Parser<StreamToken, U> {
-  return map(parser, fn: fn)
+  return map(parser(), fn: fn)
 }
 
 public func ^^<T1, T2, T3, T4, T5, T6, T7, U, StreamToken>(
-  _ parser: @escaping Parser<StreamToken, ((((((T1, T2), T3), T4), T5), T6), T7)>,
+  _ parser: @autoclosure @escaping () -> Parser<StreamToken, ((((((T1, T2), T3), T4), T5), T6), T7)>,
   fn: @escaping (T1, T2, T3, T4, T5, T6, T7) -> U
   ) -> Parser<StreamToken, U> {
-  return map(parser, fn: fn)
+  return map(parser(), fn: fn)
 }
 
 public func ^^<T1, T2, T3, T4, T5, T6, T7, T8, U, StreamToken>(
-  _ parser: @escaping Parser<StreamToken, (((((((T1, T2), T3), T4), T5), T6), T7), T8)>,
+  _ parser: @autoclosure @escaping () -> Parser<StreamToken, (((((((T1, T2), T3), T4), T5), T6), T7), T8)>,
   fn: @escaping (T1, T2, T3, T4, T5, T6, T7, T8) -> U
   ) -> Parser<StreamToken, U> {
-  return map(parser, fn: fn)
+  return map(parser(), fn: fn)
 }
 
 postfix operator *
-public postfix func *<T, StreamToken>(_ parser: @escaping Parser<StreamToken, T>) -> Parser<StreamToken, [T]> {
-  return rep(parser)
+public postfix func *<T, StreamToken>(_ parser: @autoclosure @escaping () -> Parser<StreamToken, T>) -> Parser<StreamToken, [T]> {
+  return rep(parser())
 }
 
 postfix operator +
-public postfix func +<T, StreamToken>(_ parser: @escaping Parser<StreamToken, T>) -> Parser<StreamToken, [T]> {
-  return rep1(parser)
+public postfix func +<T, StreamToken>(_ parser: @autoclosure @escaping () -> Parser<StreamToken, T>) -> Parser<StreamToken, [T]> {
+  return rep1(parser())
 }
 
 postfix operator *?
-public postfix func *?<T, StreamToken>(_ parser: @escaping Parser<StreamToken, T>) -> Parser<StreamToken, T?> {
-  return opt(parser)
+public postfix func *?<T, StreamToken>(_ parser: @autoclosure @escaping () -> Parser<StreamToken, T>) -> Parser<StreamToken, T?> {
+  return opt(parser())
 }
 

--- a/Sources/SwiftParse/Parsers.swift
+++ b/Sources/SwiftParse/Parsers.swift
@@ -63,7 +63,7 @@ public func accept(oneOf pattern: String) -> StringParser<String> {
         return .success(result)
       }
     }
-    return .failure(ParseError(at: source, reason: "Expected one of \(pattern)"))
+    return .failure(ParseError(at: source, reason: "expected one of \(pattern)"))
   }
 }
 
@@ -72,7 +72,7 @@ public func accept<T>(_ fn: @escaping (T) -> Bool) -> ArrayParser<T, T> {
     if let first = source.first, fn(first) {
       return .success((first, source.dropFirst()))
     } else {
-      return .failure(ParseError(at: source))
+      return .failure(ParseError(at: source, reason: "acceptIf failed for unknown reasons"))
     }
   }
 }
@@ -81,7 +81,7 @@ public func acceptIf<T>(_ source: ArraySlice<T>, fn: @escaping (T) -> Bool) -> P
   if let first = source.first, fn(first) {
     return .success((first, source.dropFirst()))
   } else {
-    return .failure(ParseError(at: source))
+    return .failure(ParseError(at: source, reason: "acceptIf failed for unknown reasons"))
   }
 }
 
@@ -112,13 +112,13 @@ public func reject(allOf pattern: String) -> StringParser<String> {
   return { source in
     for ch in pattern {
       if case .success = acceptIf(source, fn: { $0 == ch }) {
-        return .failure(ParseError(at: source))
+        return .failure(ParseError(at: source, reason: "did not expect \(ch)"))
       }
     }
     if let first = source.first {
       return .success((String(first), source.dropFirst()))
     } else {
-      return .failure(ParseError(at: source, reason: "One of \(pattern) matched but should not have"))
+      return .failure(ParseError(at: source, reason: "unexpectedly at end of input"))
     }
   }
 }

--- a/Sources/SwiftParse/Parsers.swift
+++ b/Sources/SwiftParse/Parsers.swift
@@ -5,9 +5,20 @@
 //  Created by Matt Gadda on 11/30/19.
 //
 
+public struct ParseError<T> : Error {
+  public let at: T
+  public let reason: String?
+  public init(at: T, reason: String? = .none) {
+    self.at = at
+    self.reason = reason
+  }
+}
+
+public typealias ParseResult<T, U> = Try<(U, T), ParseError<T>>
+
 /// A generic parser (a function) from `SourceType` to `OutputType`
 /// The remaining unparsed values are returned as the second element of the tuple.
-public typealias Parser<T, U> = (T) -> (U, T)?
+public typealias Parser<T, U> = (T) -> ParseResult<T, U>
 
 /// A parser from String to instance of type `U`
 public typealias StringParser<U> = Parser<Substring, U>
@@ -20,9 +31,9 @@ public typealias ArrayParser<T, U> = Parser<ArraySlice<T>, U>
 public func accept(_ pattern: String) -> StringParser<String> {
   return { source in
     if source.starts(with: pattern) {
-      return (pattern, source.dropFirst(pattern.count))
+      return .success((pattern, source.dropFirst(pattern.count)))
     } else {
-      return nil
+      return .failure(ParseError(at: source))
     }
   }
 }
@@ -40,41 +51,41 @@ public func accept<T: Equatable>(_ value: T) -> ArrayParser<T, T> {
   }
 }
 
-/// Generates a parser tha tmatches one of the characterse contained within `oneOf`
+/// Generates a parser that matches one of the characters contained within `oneOf`
 public func accept(oneOf pattern: String) -> StringParser<String> {
   return { source in
     for ch in pattern {
-      if let result = acceptIf(source, fn: { $0 == ch }) {
-        return result
+      if case let .success(result) = acceptIf(source, fn: { $0 == ch }) {
+        return .success(result)
       }
     }
-    return nil
+    return .failure(ParseError(at: source))
   }
 }
 
 public func accept<T>(_ fn: @escaping (T) -> Bool) -> ArrayParser<T, T> {
   return { source in
     if let first = source.first, fn(first) {
-      return (first, source.dropFirst())
+      return .success((first, source.dropFirst()))
     } else {
-      return nil
+      return .failure(ParseError(at: source))
     }
   }
 }
 
-public func acceptIf<T>(_ source: ArraySlice<T>, fn: @escaping (T) -> Bool) -> (T, ArraySlice<T>)? {
+public func acceptIf<T>(_ source: ArraySlice<T>, fn: @escaping (T) -> Bool) -> ParseResult<ArraySlice<T>, T> {
   if let first = source.first, fn(first) {
-    return (first, source.dropFirst())
+    return .success((first, source.dropFirst()))
   } else {
-    return nil
+    return .failure(ParseError(at: source))
   }
 }
 
-public func acceptIf(_ source: Substring, fn: @escaping (Substring.Element) -> Bool) -> (String, Substring)? {
+public func acceptIf(_ source: Substring, fn: @escaping (Substring.Element) -> Bool) -> ParseResult<Substring, String> {
   if let first = source.first, fn(first) {
-    return (String(first), source.dropFirst())
+    return .success((String(first), source.dropFirst()))
   } else {
-    return nil
+    return .failure(ParseError(at: source))
   }
 }
 
@@ -96,14 +107,14 @@ public func reject(character: Character) -> StringParser<String> {
 public func reject(allOf pattern: String) -> StringParser<String> {
   return { source in
     for ch in pattern {
-      if let _ = acceptIf(source, fn: { $0 == ch }) {
-        return nil
+      if case .success = acceptIf(source, fn: { $0 == ch }) {
+        return .failure(ParseError(at: source))
       }
     }
     if let first = source.first {
-      return (String(first), source.dropFirst())
+      return .success((String(first), source.dropFirst()))
     } else {
-      return nil
+      return .failure(ParseError(at: source))
     }
   }
 }
@@ -125,9 +136,10 @@ public func seq<T, U, StreamToken>(
 /// This parser never fails.
 public func rep<T, StreamToken>(_ parser: @escaping Parser<StreamToken, T>) -> Parser<StreamToken, [T]> {
   return { source in
-    // TODO: determine if recursive implementation is inefficient
+    // TODO: determine if tail call optimization happens here
+    // manually optimize if not.
     func aggregate(source: StreamToken, parsedValues: [T]) -> ([T], StreamToken) {
-      if let result = parser(source) {        
+      if case let .success(result) = parser(source) {
         return aggregate(
           source: result.1,
           parsedValues: parsedValues + [result.0]
@@ -136,7 +148,7 @@ public func rep<T, StreamToken>(_ parser: @escaping Parser<StreamToken, T>) -> P
       return (parsedValues, source)
     }
 
-    return aggregate(source: source, parsedValues: [])
+    return .success(aggregate(source: source, parsedValues: []))
   }
 }
 
@@ -155,12 +167,12 @@ public func either<T, U, StreamToken>(
   _ right: @escaping Parser<StreamToken, U>
 ) -> Parser<StreamToken, Either<T, U>> {
   return { source in
-    if let (value, remainder) = left(source) {
-      return (.left(value), remainder)
-    } else if let (value, remainder) = right(source) {
-      return (.right(value), remainder)
+    if case let .success((value, remainder)) = left(source) {
+      return .success((.left(value), remainder))
+    } else if case let .success((value, remainder)) = right(source) {
+      return .success((.right(value), remainder))
     } else {
-      return nil
+      return .failure(ParseError(at: source))
     }
   }
 }
@@ -173,12 +185,12 @@ public func or<T, StreamToken>(
   _ right: @escaping Parser<StreamToken, T>
 ) -> Parser<StreamToken, T> {
   return { source in
-    if let (value, remainder) = left(source) {
-      return (value, remainder)
-    } else if let (value, remainder) = right(source) {
-      return (value, remainder)
+    if case let .success((value, remainder)) = left(source) {
+      return .success((value, remainder))
+    } else if case let .success((value, remainder)) = right(source) {
+      return .success((value, remainder))
     } else {
-      return nil
+      return .failure(ParseError(at: source))
     }
   }
 }
@@ -189,12 +201,17 @@ public func or<T, StreamToken>(
 public func opt<T, StreamToken>(
   _ parser: @escaping Parser<StreamToken, T>
 ) -> Parser<StreamToken, T?> {
-  return { parser($0) ?? (nil, $0) }
+  return { source in
+    // this .map hack seems to be necessary to make swift
+    // convert the first non-optional value of the tuple in
+    // an optional one
+    parser(source).map { (t, u) in (t, u) } ?? (nil, source)
+  }
 }
 
 /// A stand-in parser that fails for all input. It should be used to construct mutually recursive parser definitions
-public func placeholder<T, StreamToken>(_ source: StreamToken) -> (T, StreamToken)? {
-  return nil
+public func placeholder<T, StreamToken>(_ source: StreamToken) -> ParseResult<StreamToken, T> {
+  return .failure(ParseError(at: source, reason: "Not yet implemented"))
 }
 
 // TODO: is it possible to implement generic `not` and `until` parsers?

--- a/Sources/SwiftParse/Parsers.swift
+++ b/Sources/SwiftParse/Parsers.swift
@@ -202,10 +202,11 @@ public func opt<T, StreamToken>(
   _ parser: @escaping Parser<StreamToken, T>
 ) -> Parser<StreamToken, T?> {
   return { source in
-    // this .map hack seems to be necessary to make swift
-    // convert the first non-optional value of the tuple in
-    // an optional one
-    parser(source).map { (t, u) in (t, u) } ?? (nil, source)
+    // TODO: define primitive on Try to support this case
+    switch parser(source) {
+    case let .success(s): return .success(s)
+    case .failure: return .success((nil, source))
+    }
   }
 }
 

--- a/Sources/SwiftParse/Try.swift
+++ b/Sources/SwiftParse/Try.swift
@@ -23,7 +23,7 @@ public enum Try<T, U: Error> {
   public func get() throws -> T {
     switch self {
     case let .success(t): return t
-    case let .failure(e): throw e
+    case let .failure(f): throw f
     }
   }
 }

--- a/Sources/SwiftParse/Try.swift
+++ b/Sources/SwiftParse/Try.swift
@@ -27,11 +27,3 @@ public enum Try<T, U: Error> {
     }
   }
 }
-
-infix operator ??
-public func ??<T, U>(try: Try<T, U>, defaultValue: @autoclosure () throws -> T) rethrows -> T {
-  switch `try` {
-  case let .success(s): return s
-  case .failure: return try defaultValue()
-  }
-}

--- a/Sources/SwiftParse/Try.swift
+++ b/Sources/SwiftParse/Try.swift
@@ -1,0 +1,37 @@
+//
+//  Try.swift
+//  SwiftParse
+//
+//  Created by Matt Gadda on 12/8/19.
+//
+
+public enum Try<T, U: Error> {
+  case success(T)
+  case failure(U)
+  public func map<W>(fn: (T) -> W) -> Try<W, U> {
+    switch self {
+    case let .success(t): return .success(fn(t))
+    case let .failure(f): return .failure(f)
+    }
+  }
+  public func flatMap<W>(fn: (T) -> Try<W, U>) -> Try<W, U> {
+    switch self {
+    case let .success(t): return fn(t)
+    case let .failure(f): return .failure(f)
+    }
+  }
+  public func get() throws -> T {
+    switch self {
+    case let .success(t): return t
+    case let .failure(e): throw e
+    }
+  }  
+}
+
+infix operator ??
+public func ??<T, U>(try: Try<T, U>, else: T) -> Try<T, U> {
+  switch `try` {
+  case .success: return `try`
+  case .failure: return .success(`else`)
+  }
+}

--- a/Sources/SwiftParse/Try.swift
+++ b/Sources/SwiftParse/Try.swift
@@ -25,13 +25,13 @@ public enum Try<T, U: Error> {
     case let .success(t): return t
     case let .failure(e): throw e
     }
-  }  
+  }
 }
 
 infix operator ??
-public func ??<T, U>(try: Try<T, U>, else: T) -> Try<T, U> {
+public func ??<T, U>(try: Try<T, U>, defaultValue: @autoclosure () throws -> T) rethrows -> T {
   switch `try` {
-  case .success: return `try`
-  case .failure: return .success(`else`)
+  case let .success(s): return s
+  case .failure: return try defaultValue()
   }
 }

--- a/Tests/SwiftParseTests/ParserHelpers.swift
+++ b/Tests/SwiftParseTests/ParserHelpers.swift
@@ -23,19 +23,24 @@ extension ParserHelpers {
     file: StaticString = #file,
     line: UInt = #line
   ) {
-    let result: (U, T)? = parser(input)
-    XCTAssertNotNil(result)
-    XCTAssertEqual(result!.0, val, message(), file: file, line: line)
-    XCTAssertEqual(result!.1, remaining, message(), file: file, line: line)
+    switch parser(input) {
+    case let .success(s):
+        XCTAssertEqual(s.0, val, message(), file: file, line: line)
+        XCTAssertEqual(s.1, remaining, message(), file: file, line: line)
+    case let .failure(e): XCTFail("Failed to parse at \(e.at)", file: file, line: line)
+    }    
   }
 
   func assertNotParsed<T: Equatable, U: Equatable>(
-    _ parser: (T) -> (U, T)?,
+    _ parser: Parser<T, U>,
     input: T,
     _ message: @autoclosure () -> String = "",
     file: StaticString = #file,
     line: UInt = #line
   ) {
-    XCTAssertNil(parser(input))
+    switch parser(input) {
+    case .success: XCTFail(message(), file: file, line: line)
+    case .failure: return
+    }
   }
 }

--- a/Tests/SwiftParseTests/ParsersTests.swift
+++ b/Tests/SwiftParseTests/ParsersTests.swift
@@ -8,7 +8,7 @@ final class ParserTests: XCTestCase, ParserHelpers {
   enum Token : Equatable {
     case int(Int)
   }
-  
+    
   func testAcceptIfString() {
     let digit: StringParser<String> = { source in
       acceptIf(source) { char in char >= "0" && char <= "9" }
@@ -73,23 +73,23 @@ final class ParserTests: XCTestCase, ParserHelpers {
 
   func testSeqArray() {
     let parser = seq(accept(1), accept(2))
-    let result = parser([1,2,3])
+    let result = try! parser([1,2,3]).get()
     let val = (1,2)
     let remaining = [3]
-
-    XCTAssert(result!.0 == val, "was \(val)")
-    XCTAssertEqual(Array(result!.1), remaining)
+        
+    XCTAssert(result.0 == val, "was \(val)")
+    XCTAssertEqual(Array(result.1), remaining)
   }
 
   func testSeqString() {
     let parser = seq(accept("a"), accept("b"))
-    let result = parser("abcd")
+    let result = try! parser("abcd").get()
     let val = ("a", "b")
     let remaining = "cd"
 
     // TODO: should value be "ab" for strings? and ["a", "b"] for arrays?
-    XCTAssert(result!.0 == val, "expected: \(val) got: \(result!.0)")
-    XCTAssertEqual(String(result!.1), remaining)
+    XCTAssert(result.0 == val, "expected: \(val) got: \(result.0)")
+    XCTAssertEqual(String(result.1), remaining)
   }
 
   func testMultiSeq() {


### PR DESCRIPTION
This is the first of at least two rounds of improvements error handling. In this PR, parsers now have the ability to fail and return a reason for failure. High order parsers can choose to propagate errors from their children as appropriate. 