### PR TITLE
FIX: Pattern match tuple in `case let`

### DIFF
--- a/Sources/SwiftParse/Parsers.swift
+++ b/Sources/SwiftParse/Parsers.swift
@@ -460,7 +460,7 @@ public func and<T, U, V, LeftValue, RightValue>(
   _ right: @autoclosure @escaping () -> Parser<T, RightValue, V>) -> Parser<T, LeftValue, U> {
   return { source in
     switch (left()(source), right()(source)) {
-    case let (.success(value, out), .success):
+    case let (.success((value, out)), .success):
       return .success((value, out))
     case let (.failure(error), _):
       return .failure(ParseError(at: error.at, reason: error.reason))


### PR DESCRIPTION
**Problems**

Pattern match for a tuple in `case let` in `enum` has missing `()`, for which Swift compiler emits warnings.

**Solution**

Add `()` in it.